### PR TITLE
Adjusted example configs to show example of JWT_SECRET and CORS_ORIGINS

### DIFF
--- a/site/content/docs/setup/examples/nginx-http-docker-compose.yml
+++ b/site/content/docs/setup/examples/nginx-http-docker-compose.yml
@@ -13,8 +13,8 @@ services:
       - data:/data
     environment:
       # !!! REPLACE These !!!
-      JWT_SECRET: "bXktc2VjcmV0"
-      CORS_ORIGINS: "*"
+      JWT_SECRET: "UL4/Yf2ix8dhxy8MDjutrhGN7DT8qnf2ZNNM9TPGGBw="
+      CORS_ORIGINS: "http://example.com"
 
   frontend:
     image: ghcr.io/enchant97/note-mark-frontend

--- a/site/content/docs/setup/examples/nginx-http-docker-compose.yml
+++ b/site/content/docs/setup/examples/nginx-http-docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - data:/data
     environment:
       # !!! REPLACE These !!!
-      JWT_SECRET: "UL4/Yf2ix8dhxy8MDjutrhGN7DT8qnf2ZNNM9TPGGBw="
+      JWT_SECRET: "bXktc2VjcmV0"
       CORS_ORIGINS: "http://example.com"
 
   frontend:

--- a/site/content/docs/setup/examples/postgres-docker-compose.yml
+++ b/site/content/docs/setup/examples/postgres-docker-compose.yml
@@ -14,8 +14,8 @@ services:
       - backend_data:/data
     environment:
       # !!! REPLACE These !!!
-      JWT_SECRET: "bXktc2VjcmV0"
-      CORS_ORIGINS: "*"
+      JWT_SECRET: "qDSFr/3Mq9zX+CVYtlSjpmJyYMNXYGBNLDSu51RAuNQ="
+      CORS_ORIGINS: "https://example.com:8000"
       DB__TYPE: postgres
       DB__URI: "host=db user=postgres password=postgres dbname=notemark port=5432 sslmode=disable TimeZone=Europe/London"
     ports:

--- a/site/content/docs/setup/examples/postgres-docker-compose.yml
+++ b/site/content/docs/setup/examples/postgres-docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - backend_data:/data
     environment:
       # !!! REPLACE These !!!
-      JWT_SECRET: "qDSFr/3Mq9zX+CVYtlSjpmJyYMNXYGBNLDSu51RAuNQ="
+      JWT_SECRET: "bXktc2VjcmV0"
       CORS_ORIGINS: "https://example.com:8000"
       DB__TYPE: postgres
       DB__URI: "host=db user=postgres password=postgres dbname=notemark port=5432 sslmode=disable TimeZone=Europe/London"


### PR DESCRIPTION
Hello!

I saw you already added the tips on generating the JWT_SECRET and what to put for CORS_ORIGIN. I just updated the example configs to show what they might look like. Just a suggestion.

I'm also happy to add another example config. My use case is using docker compose to deploy the frontend and backend containers, but using my local nginx installation with a subdomain to proxy to those containers. It's not very complicated, so not sure how much use it actually will be for self-hosters. Please let me know what you think!