### PR TITLE
Allow tab to indent text in editor

### DIFF
--- a/frontend/src/components/editor/editor.tsx
+++ b/frontend/src/components/editor/editor.tsx
@@ -6,6 +6,7 @@ import { Accessor, Component, For, createEffect, createSignal, onCleanup, onMoun
 import { SetStoreFunction, Store } from "solid-js/store";
 import Icon from "../icon";
 import { keymap } from "@codemirror/view";
+import {indentWithTab} from "@codemirror/commands"
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import { useModal } from "../../contexts/ModalProvider";
 import CreateLinkModal from "./modals/create_link";
@@ -169,6 +170,7 @@ const Editor: Component<EditorProps> = (props) => {
             }
           }),
           keymap.of([
+            indentWithTab,
             {
               key: "Mod-s", run: () => {
                 if (!props.state.saving)


### PR DESCRIPTION
I use bulleted lists a lot when editing markdown context. Needed to use the button is not ideal assuming people are spending a lot of time editing documents. This code includes normal tab behavior most users would expect from an editor.

## Current behavior
Hitting the "tab" key results in my focus shifting around the page.

## Desired behavior
Hitting the "tab" key results in indenting the selection
Hitting the "shift+tab" keys results in removing indents from the selection