### PR TITLE
feat(api): expose the running version on /api/info

### DIFF
--- a/backend/cli/cli.go
+++ b/backend/cli/cli.go
@@ -23,9 +23,9 @@ func Entrypoint(appVersion string) error {
 			{
 				Name:  "serve",
 				Usage: "run the api server",
-				Action: func(ctx *cli.Context) error {
-					return commandServe(appConfig)
-				},
+			Action: func(ctx *cli.Context) error {
+				return commandServe(appConfig, appVersion)
+			},
 			},
 			{
 				Name:  "clean",

--- a/backend/cli/serve.go
+++ b/backend/cli/serve.go
@@ -14,7 +14,7 @@ import (
 	"github.com/enchant97/note-mark/backend/storage"
 )
 
-func commandServe(appConfig config.AppConfig) error {
+func commandServe(appConfig config.AppConfig, appVersion string) error {
 	// Connect to storage backend
 	storage_backend := storage.DiskController{}.New(appConfig.DataPath)
 	if err := storage_backend.Setup(); err != nil {
@@ -25,7 +25,7 @@ func commandServe(appConfig config.AppConfig) error {
 	if err := db.InitDB(appConfig.DB); err != nil {
 		return err
 	}
-	if mux, err := handlers.SetupHandlers(appConfig, storage_backend); err != nil {
+	if mux, err := handlers.SetupHandlers(appConfig, storage_backend, appVersion); err != nil {
 		return err
 	} else {
 		// Start server

--- a/backend/core/types.go
+++ b/backend/core/types.go
@@ -57,6 +57,7 @@ type OidcProviderInfo struct {
 }
 
 type ServerInfo struct {
+	Version                   string            `json:"version"`
 	MinSupportedVersion       string            `json:"minSupportedVersion"`
 	AllowInternalSignup       bool              `json:"allowInternalSignup"`
 	AllowInternalLogin        bool              `json:"allowInternalLogin"`

--- a/backend/handlers/misc.go
+++ b/backend/handlers/misc.go
@@ -8,9 +8,10 @@ import (
 	"github.com/enchant97/note-mark/backend/core"
 )
 
-func SetupMiscHandler(api huma.API, appConfig config.AppConfig) {
+func SetupMiscHandler(api huma.API, appConfig config.AppConfig, appVersion string) {
 	miscHandler := MiscHandler{
 		AppConfig: appConfig,
+		Version:   appVersion,
 	}
 	huma.Get(api, "/api/info", miscHandler.GetServerInfo)
 }
@@ -21,6 +22,7 @@ type GetServerInfoOutput struct {
 
 type MiscHandler struct {
 	AppConfig config.AppConfig
+	Version   string
 }
 
 func (h MiscHandler) GetServerInfo(ctx context.Context, input *struct{}) (*GetServerInfoOutput, error) {
@@ -34,6 +36,7 @@ func (h MiscHandler) GetServerInfo(ctx context.Context, input *struct{}) (*GetSe
 	}
 	return &GetServerInfoOutput{
 		Body: core.ServerInfo{
+			Version:                   h.Version,
 			MinSupportedVersion:       "0.17.0",
 			AllowInternalSignup:       h.AppConfig.EnableInternalSignup,
 			AllowInternalLogin:        h.AppConfig.EnableInternalLogin,

--- a/backend/handlers/utils.go
+++ b/backend/handlers/utils.go
@@ -18,7 +18,8 @@ import (
 
 func SetupHandlers(
 	appConfig config.AppConfig,
-	storage_backend storage.StorageController) (http.Handler, error) {
+	storage_backend storage.StorageController,
+	appVersion string) (http.Handler, error) {
 	mux := chi.NewRouter()
 	mux.Use(func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -47,7 +48,7 @@ func SetupHandlers(
 		strings.HasPrefix(appConfig.PublicUrl, "https://"),
 	)
 	api.UseMiddleware(authProvider.ProviderMiddleware)
-	SetupMiscHandler(api, appConfig)
+	SetupMiscHandler(api, appConfig, appVersion)
 	SetupAuthHandler(api, appConfig, authProvider)
 	SetupUsersHandler(api, appConfig, authProvider)
 	SetupBooksHandler(api, authProvider)


### PR DESCRIPTION
## What

The /api/info endpoint returns a small ServerInfo document with capability flags and an OIDC pointer, but it never includes the version. The version is injected at build time into main.go's `var Version` and used by the CLI to print `notemark --version`, but the API never sees it. Frontends comparing themselves against `minSupportedVersion` had to fall back to other heuristics.

Plumb the build-time `Version` through Entrypoint -> commandServe -> SetupHandlers -> SetupMiscHandler and add a `Version` field to `core.ServerInfo`. No changes to existing fields; the wire shape only gains one optional string.

## Why

Symmetry: the CLI knows its version, the API does not. The version is the most natural value to put in a /api/info response, and now a deployed build can be identified by the same string whether you ask the CLI or the server.

## How

- Add `Version string` to `core.ServerInfo` with the json tag `version`.
- `MiscHandler` gains a `Version` field; `SetupMiscHandler` now takes an `appVersion string` and threads it through.
- `SetupHandlers` takes the same string and forwards it to `SetupMiscHandler`.
- `commandServe` takes the same string and forwards it to `SetupHandlers`.
- `Entrypoint` was already passing `appVersion` to `cli.App.Version`; it now also passes it to `commandServe`.

## Notes

- The new field is always populated because `main.go` initialises `Version` to `"unknown"` if the build flag is absent; clients can detect that case without a separate null check.
- I could not run `go build` here (no Go module cache for this repo in the container), but the change is mechanical and limited to five files; pre-existing TS/JS lint noise in the repo is untouched.